### PR TITLE
chore: set `coveralls` as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/jest": "^23.3.1",
     "@types/lodash": "^4.14.113",
     "@types/node": "^10.5.3",
+    "coveralls": "^3.0.2",
     "husky": "^0.14.3",
     "jest": "^23.4.2",
     "lint-staged": "^7.2.0",
@@ -26,7 +27,6 @@
     "typescript": "^2.9.2"
   },
   "dependencies": {
-    "coveralls": "^3.0.2",
     "expression-eval": "^1.3.0",
     "ip": "^1.1.5",
     "lodash": "^4.17.10"


### PR DESCRIPTION
ref: https://github.com/casbin/node-casbin/pull/37